### PR TITLE
old client-cloud doesn't accept s3 other than us-east-1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+config.edn
 .cpcache
 temp/
+target/
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  {org.clojure/data.csv {:mvn/version "0.1.4"}
   org.clojure/data.json {:mvn/version "0.2.6"}
   org.clojure/data.generators {:mvn/version "0.1.2"}
-  org.clojure/clojure {:mvn/version "1.9.0-beta2"}
-  com.datomic/client-cloud {:mvn/version "0.8.44"}
+  org.clojure/clojure {:mvn/version "1.9.0"}
+  com.datomic/client-cloud {:mvn/version "0.8.50"}
   seesaw/seesaw {:mvn/version "1.4.5"}}
  :paths ["src" "tutorial" "doc-examples" "resources"]}


### PR DESCRIPTION
I got the following error message when I tried to create a db. 

```
user=> (d/create-database client {:db-name "movies"})
ExceptionInfo The bucket is in this region: us-west-2. Please use this region to retry the request (Service: Amazon S3; Status Code: 301; Error Code: PermanentRedirect; Request ID: D46EBE20FB7938B0; S3 Extended Request ID: DiuVAMjTtCd1uvBpiu2teNE4oeP4Dg/jc3hYC1xCv7kLSQUUZ65LfBSR6j46bpGObEDd8fr49Pc=)  clojure.core/ex-info (core.clj:4744)
```
Looks like the old version of datomic cloud client lib doesn't support regions other than us-east-1. I confirmed it was resolved by bumping up the lib. 

I also upgraded clojure to 1.9 GA, and added `config.edn` to `.gitignore` preventing people from checking in their credentials by accident. 
